### PR TITLE
Save gift ideas to Supabase database

### DIFF
--- a/database-setup.sql
+++ b/database-setup.sql
@@ -50,8 +50,20 @@ create policy "Authenticated users can manage kids"
     using (auth.role() = 'authenticated');
 
 -- Policies for gifts table
-create policy "Users can manage their own gifts"
-    on gifts for all
+create policy "Authenticated users can read gifts"
+    on gifts for select
+    using (auth.role() = 'authenticated');
+
+create policy "Users can insert their own gifts"
+    on gifts for insert
+    with check (auth.uid() = user_id);
+
+create policy "Users can update their own gifts"
+    on gifts for update
+    using (auth.uid() = user_id);
+
+create policy "Users can delete their own gifts"
+    on gifts for delete
     using (auth.uid() = user_id);
 
 -- Policies for kid_gifts table


### PR DESCRIPTION
Update Supabase RLS policies for the `gifts` table to allow all authenticated users to read and owners to manage their own gift ideas.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b53b9b5-0dcf-4405-93bf-327adfe8d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b53b9b5-0dcf-4405-93bf-327adfe8d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

