### PR TITLE
Style sign out button with theme red

### DIFF
--- a/style.css
+++ b/style.css
@@ -218,10 +218,10 @@ body {
   display: flex;
   align-items: center;
   gap: 15px;
-  background: none;
-  border: none;
+  background: transparent;
+  border: 1px solid var(--color-secondary);
   cursor: pointer;
-  color: var(--color-text);
+  color: var(--color-secondary);
   width: calc(100% - 20px);
   border-radius: 8px;
   text-align: left;
@@ -230,8 +230,13 @@ body {
 }
 
 .sidebar-signout:hover {
-  background-color: var(--color-bg);
-  color: var(--color-secondary);
+  background-color: var(--color-secondary);
+  color: var(--color-surface);
+}
+
+.sidebar-signout:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 2px;
 }
 
 .sidebar-signout svg {


### PR DESCRIPTION
Update sign-out button styling to use the theme's red for better visibility and emphasis.

---
<a href="https://cursor.com/background-agent?bcId=bc-a47883d2-848c-4744-a325-a724eb1b3570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a47883d2-848c-4744-a325-a724eb1b3570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

