### PR TITLE
Set default size for gift ideas textbox

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -136,7 +136,7 @@
       <h3 class="form-title">Your Gift Ideas</h3>
       <p class="helper-text">Add gift ideas you would like to receive. Only you can submit ideas for yourself.</p>
       <label for="adultGiftIdeas">Gift Ideas for You:</label>
-      <textarea id="adultGiftIdeas" name="giftIdeas" rows="4" required></textarea>
+      <textarea id="adultGiftIdeas" name="giftIdeas" rows="12" required></textarea>
       <button type="submit" class="submit-btn">Add My Gift Ideas</button>
     </form>
 

--- a/Index.html.new
+++ b/Index.html.new
@@ -18,7 +18,7 @@
       <h3 class="form-title">Your Gift Ideas</h3>
       <p class="helper-text">Add gift ideas you would like to receive. Only you can submit ideas for yourself.</p>
       <label for="adultGiftIdeas">Gift Ideas for You:</label>
-      <textarea id="adultGiftIdeas" name="giftIdeas" rows="4" required></textarea>
+      <textarea id="adultGiftIdeas" name="giftIdeas" rows="12" required></textarea>
       <button type="submit" class="submit-btn">Add My Gift Ideas</button>
     </form>
 

--- a/style.css
+++ b/style.css
@@ -370,7 +370,7 @@ body {
 
 .gift-form textarea {
   resize: vertical;
-  min-height: 80px;
+  min-height: 240px;
 }
 
 .btn-primary {


### PR DESCRIPTION
Increase the default size of the "Your Gift Ideas" textarea to match the requested visual size.

---
<a href="https://cursor.com/background-agent?bcId=bc-07dc43e2-c3ef-460e-aa5b-7b928778dfc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07dc43e2-c3ef-460e-aa5b-7b928778dfc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

