### PR TITLE
Set default kids gift box size

### DIFF
--- a/style.css
+++ b/style.css
@@ -627,6 +627,11 @@ textarea {
   box-sizing: border-box;
 }
 
+/* Make kids gift ideas box larger by default */
+#kidsGiftIdeas {
+  min-height: 260px;
+}
+
 select:focus,
 textarea:focus {
   outline: 2px solid var(--color-link);


### PR DESCRIPTION
Increase the default height of the kids gift ideas textarea to match the desired larger default size.

---
<a href="https://cursor.com/background-agent?bcId=bc-347c3c29-c5f3-40a4-90b3-011544360b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-347c3c29-c5f3-40a4-90b3-011544360b53">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

