### PR TITLE
Add purchasable item links with previews

### DIFF
--- a/style.css
+++ b/style.css
@@ -425,6 +425,38 @@ body {
   opacity: 0.8;
 }
 
+/* Simple link preview */
+.link-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-top: 6px;
+}
+.link-favicon {
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+}
+.link-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.link-domain {
+  color: var(--color-link);
+  text-decoration: none;
+  font-weight: 600;
+}
+.link-domain:hover { text-decoration: underline; }
+.link-action {
+  color: #64748b;
+  font-size: 12px;
+}
+
 .gift-item-actions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
Enable users to add titled, active links with previews to adult and kid gift items without creating separate gift lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-97107416-f97a-4467-b943-84419f543bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97107416-f97a-4467-b943-84419f543bc8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

