### PR TITLE
Restore secret santa heading above green box

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -59,6 +59,9 @@
 
   <!-- Main Content -->
   <main class="main-content">
+    <div class="topbar-center">
+      <h1 class="brand-title">Secret Santa</h1>
+    </div>
     <div id="welcomeBanner" class="welcome-banner">
       <span id="welcomeMessage"></span>
     </div>


### PR DESCRIPTION
Add "Secret Santa" heading to `Index.html` to restore it at the top of the page.

---
<a href="https://cursor.com/background-agent?bcId=bc-80b89c6a-65c7-4015-a4aa-eb0b85022209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80b89c6a-65c7-4015-a4aa-eb0b85022209">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

