### PR TITLE
Add settings tab to side menu

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -47,6 +47,13 @@
         </svg>
         Set Recipient
       </button>
+
+      <button id="settingsBtn" class="sidebar-button">
+        <svg viewBox="0 0 24 24" width="24" height="24">
+          <path fill="currentColor" d="M12,15.5A3.5,3.5 0 1,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.98C19.47,12.66 19.5,12.34 19.5,12C19.5,11.66 19.47,11.34 19.43,11.02L21.54,9.37C21.73,9.22 21.78,8.96 21.66,8.75L19.66,5.25C19.54,5.04 19.28,4.97 19.06,5.05L16.56,6.05C16,5.64 15.39,5.31 14.73,5.07L14.33,2.42C14.29,2.18 14.09,2 13.84,2H10.16C9.91,2 9.71,2.18 9.67,2.42L9.27,5.07C8.61,5.31 8,5.64 7.44,6.05L4.94,5.05C4.72,4.97 4.46,5.04 4.34,5.25L2.34,8.75C2.22,8.96 2.27,9.22 2.46,9.37L4.57,11.02C4.53,11.34 4.5,11.66 4.5,12C4.5,12.34 4.53,12.66 4.57,12.98L2.46,14.63C2.27,14.78 2.22,15.04 2.34,15.25L4.34,18.75C4.46,18.96 4.72,19.03 4.94,18.95L7.44,17.95C8,18.36 8.61,18.69 9.27,18.93L9.67,21.58C9.71,21.82 9.91,22 10.16,22H13.84C14.09,22 14.29,21.82 14.33,21.58L14.73,18.93C15.39,18.69 16,18.36 16.56,17.95L19.06,18.95C19.28,19.03 19.54,18.96 19.66,18.75L21.66,15.25C21.78,15.04 21.73,14.78 21.54,14.63L19.43,12.98Z" />
+        </svg>
+        Settings
+      </button>
     </div>
     
     <button onclick="signOut()" class="sidebar-signout">
@@ -126,6 +133,26 @@
           <div id="recipientStatus" class="helper-text" style="margin-bottom:12px;"></div>
           <select id="recipientSelect"></select>
           <button id="saveRecipientBtn" class="btn-primary" style="margin-top:10px;">Save Recipient</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Settings Modal -->
+    <div id="settingsModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Settings</h2>
+          <button class="modal-close">&times;</button>
+        </div>
+        <div class="modal-body">
+          <form id="settingsForm" class="settings-form">
+            <label class="setting-item">
+              <input type="checkbox" id="settingPinSidebar">
+              Pin sidebar by default
+            </label>
+            <div class="helper-text">These settings are saved on this device.</div>
+            <button type="submit" class="btn-primary" style="margin-top:10px;">Save Settings</button>
+          </form>
         </div>
       </div>
     </div>

--- a/sidebar.js
+++ b/sidebar.js
@@ -11,10 +11,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const kidsGiftListBtn = document.getElementById('kidsGiftList');
     const recipientGiftsBtn = document.getElementById('recipientGifts');
     const setRecipientBtn = document.getElementById('setRecipient');
+    const settingsBtn = document.getElementById('settingsBtn');
     const myGiftListModal = document.getElementById('myGiftListModal');
     const kidsGiftListModal = document.getElementById('kidsGiftListModal');
     const recipientGiftsModal = document.getElementById('recipientGiftsModal');
     const setRecipientModal = document.getElementById('setRecipientModal');
+    const settingsModal = document.getElementById('settingsModal');
+    const settingsForm = document.getElementById('settingsForm');
+    const settingPinSidebar = document.getElementById('settingPinSidebar');
     const closeButtons = document.querySelectorAll('.modal-close');
     const myGiftsList = document.getElementById('myGiftsList');
     const addGiftForm = document.getElementById('addGiftForm');
@@ -28,6 +32,31 @@ document.addEventListener('DOMContentLoaded', () => {
     const badgeMyGifts = document.getElementById('badgeMyGifts');
     const badgeKids = document.getElementById('badgeKids');
     let currentModal = null;
+
+    // Settings helpers
+    function getSettings() {
+        try { return JSON.parse(localStorage.getItem('app_settings') || '{}'); } catch { return {}; }
+    }
+
+    function saveSettings(settings) {
+        try { localStorage.setItem('app_settings', JSON.stringify(settings || {})); } catch {}
+    }
+
+    function applyPinnedFromSettings(settings) {
+        const wantPinned = !!settings?.pinSidebarDefault;
+        if (wantPinned) {
+            sidebar.classList.add('pinned');
+            sidebarPin?.classList.add('active');
+            if (appBar) appBar.classList.add('pinned');
+        } else {
+            sidebar.classList.remove('pinned');
+            sidebarPin?.classList.remove('active');
+            if (appBar) appBar.classList.remove('pinned');
+        }
+    }
+
+    // Apply saved settings on load
+    applyPinnedFromSettings(getSettings());
 
     // Sidebar pin toggle
     sidebarPin.addEventListener('click', () => {
@@ -256,6 +285,10 @@ document.addEventListener('DOMContentLoaded', () => {
             saveRecipientBtn.disabled = locked;
             await populateRecipientOptions();
         }
+        if (modal === settingsModal) {
+            const s = getSettings();
+            if (settingPinSidebar) settingPinSidebar.checked = !!s.pinSidebarDefault;
+        }
 
         // Show the modal
         modal.style.display = 'flex';
@@ -289,12 +322,12 @@ document.addEventListener('DOMContentLoaded', () => {
             currentModal = null;
         }
         // Clear active state when closing any modal
-        [myGiftListBtn, kidsGiftListBtn, recipientGiftsBtn, setRecipientBtn].forEach(b => b && b.classList.remove('active'));
+        [myGiftListBtn, kidsGiftListBtn, recipientGiftsBtn, setRecipientBtn, settingsBtn].forEach(b => b && b.classList.remove('active'));
     }
 
     // Open modals from sidebar buttons
     const markActive = (btn) => {
-        [myGiftListBtn, kidsGiftListBtn, recipientGiftsBtn, setRecipientBtn].forEach(b => b && b.classList.remove('active'));
+        [myGiftListBtn, kidsGiftListBtn, recipientGiftsBtn, setRecipientBtn, settingsBtn].forEach(b => b && b.classList.remove('active'));
         btn && btn.classList.add('active');
     };
 
@@ -320,6 +353,22 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         markActive(setRecipientBtn);
         await openModal(setRecipientModal);
+    });
+
+    settingsBtn?.addEventListener('click', async (e) => {
+        e.preventDefault();
+        markActive(settingsBtn);
+        await openModal(settingsModal);
+    });
+
+    settingsForm?.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const s = getSettings();
+        s.pinSidebarDefault = !!settingPinSidebar?.checked;
+        saveSettings(s);
+        applyPinnedFromSettings(s);
+        showToast('Settings saved');
+        closeModal(settingsModal);
     });
 
     saveRecipientBtn.addEventListener('click', async () => {

--- a/style.css
+++ b/style.css
@@ -513,6 +513,20 @@ body {
   }
 }
 
+/* Settings */
+.settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.setting-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 500;
+}
+
 @keyframes fade-out {
   from {
     transform: translateX(0);


### PR DESCRIPTION
Add a settings tab to the sidebar with a 'Pin sidebar by default' option, persisted via local storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-0344ee64-6b9c-4dcb-97f9-c95ffdfaf871">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0344ee64-6b9c-4dcb-97f9-c95ffdfaf871">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

