### PR TITLE
Add website theme selection to settings

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -156,6 +156,14 @@
               <input type="checkbox" id="settingPinSidebar">
               Pin sidebar by default
             </label>
+            <div class="setting-item">
+              <label for="settingTheme" style="margin: 0;">Theme</label>
+              <select id="settingTheme">
+                <option value="system">System theme</option>
+                <option value="light">Light theme</option>
+                <option value="dark">Dark theme</option>
+              </select>
+            </div>
             <div class="helper-text">These settings are saved on this device.</div>
             <button type="submit" class="btn-primary" style="margin-top:10px;">Save Settings</button>
           </form>

--- a/sidebar.js
+++ b/sidebar.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const settingsModal = document.getElementById('settingsModal');
     const settingsForm = document.getElementById('settingsForm');
     const settingPinSidebar = document.getElementById('settingPinSidebar');
+    const settingTheme = document.getElementById('settingTheme');
     const closeButtons = document.querySelectorAll('.modal-close');
     const myGiftsList = document.getElementById('myGiftsList');
     const addGiftForm = document.getElementById('addGiftForm');
@@ -55,8 +56,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function applyThemeFromSettings(settings) {
+        const raw = (settings && settings.theme) ? settings.theme : 'system';
+        const applied = (raw === 'light' || raw === 'dark') ? raw : 'system';
+        document.documentElement.setAttribute('data-theme', applied);
+    }
+
     // Apply saved settings on load
-    applyPinnedFromSettings(getSettings());
+    (function initSettingsOnLoad(){
+        const s = getSettings();
+        applyPinnedFromSettings(s);
+        applyThemeFromSettings(s);
+    })();
 
     // Sidebar pin toggle
     sidebarPin.addEventListener('click', () => {
@@ -288,6 +299,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (modal === settingsModal) {
             const s = getSettings();
             if (settingPinSidebar) settingPinSidebar.checked = !!s.pinSidebarDefault;
+            if (settingTheme) settingTheme.value = s.theme || 'system';
         }
 
         // Show the modal
@@ -365,8 +377,10 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         const s = getSettings();
         s.pinSidebarDefault = !!settingPinSidebar?.checked;
+        s.theme = settingTheme?.value || 'system';
         saveSettings(s);
         applyPinnedFromSettings(s);
+        applyThemeFromSettings(s);
         showToast('Settings saved');
         closeModal(settingsModal);
     });

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 :root {
   /* Core palette */
+  --color-page-bg: #E6EEE6;
   --color-bg: #FAF8F5; /* soft ivory */
   --color-surface: #FFFFFF; /* clean cards */
   --color-text: #1F2937; /* slate 800 */
@@ -10,6 +11,7 @@
   --color-accent: #C8A858; /* muted gold */
   --color-border: #E7E5E4; /* stone 200 */
   --color-link: #2563EB; /* blue 600 */
+  --color-page-bg: #E6EEE6;
   
   /* Status colors */
   --status-info: #2563EB;
@@ -23,6 +25,51 @@
   --sidebar-collapsed-width: 60px;
 }
 
+/* Dark theme variables */
+[data-theme='dark'] {
+  --color-page-bg: #0f1620;
+  --color-bg: #0f1620;
+  --color-surface: #131c28;
+  --color-text: #E5E7EB;
+  --color-primary: #2DD4BF;
+  --color-primary-700: #14B8A6;
+  --color-secondary: #F43F5E;
+  --color-secondary-700: #E11D48;
+  --color-accent: #F59E0B;
+  --color-border: #1f2a37;
+  --color-link: #60A5FA;
+
+  --status-info: #60A5FA;
+  --status-hold: #D97706;
+  --status-done: #10B981;
+  --status-error: #EF4444;
+  --status-success: #10B981;
+}
+
+/* System theme follows prefers-color-scheme */
+[data-theme='system'] { }
+@media (prefers-color-scheme: dark) {
+  [data-theme='system'] {
+    --color-page-bg: #0f1620;
+    --color-bg: #0f1620;
+    --color-surface: #131c28;
+    --color-text: #E5E7EB;
+    --color-primary: #2DD4BF;
+    --color-primary-700: #14B8A6;
+    --color-secondary: #F43F5E;
+    --color-secondary-700: #E11D48;
+    --color-accent: #F59E0B;
+    --color-border: #1f2a37;
+    --color-link: #60A5FA;
+
+    --status-info: #60A5FA;
+    --status-hold: #D97706;
+    --status-done: #10B981;
+    --status-error: #EF4444;
+    --status-success: #10B981;
+  }
+}
+
 /* Reset and Base Styles */
 * {
   margin: 0;
@@ -33,7 +80,7 @@
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   /* Sage green background with subtle accents */
-  background: #E6EEE6;
+  background: var(--color-page-bg);
   background-attachment: fixed;
   background-repeat: no-repeat;
   color: var(--color-text);
@@ -56,7 +103,7 @@ body {
 .user-avatar {
   width: 32px; height: 32px; border-radius: 50%;
   border: 1px solid var(--color-border);
-  background: #fff; color: var(--color-primary);
+  background: var(--color-surface); color: var(--color-primary);
   display: flex; align-items: center; justify-content: center;
   font-weight: 700; cursor: pointer;
 }
@@ -401,7 +448,7 @@ body {
 
 /* Compact variant for dense lists inside modals */
 .gift-item.compact {
-  background-color: #fbfbfb;
+  background-color: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 8px 10px;
@@ -629,7 +676,7 @@ textarea {
   padding: 12px;
   border: 1.5px solid var(--color-border);
   border-radius: 6px;
-  background: #fff;
+  background: var(--color-surface);
   color: var(--color-text);
   font-size: 1em;
   margin-bottom: 16px;


### PR DESCRIPTION
Add a theme selector to settings, allowing users to choose between system, light, and dark themes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0d430e5-29dc-43f0-9344-0ae22e8aa385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0d430e5-29dc-43f0-9344-0ae22e8aa385">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

