### PR TITLE
Set default currency to USD

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -156,6 +156,14 @@
               <input type="checkbox" id="settingPinSidebar">
               Pin sidebar by default
             </label>
+            <label for="settingCurrency">Currency</label>
+            <select id="settingCurrency">
+              <option value="USD">USD — $ US Dollar</option>
+              <option value="EUR">EUR — € Euro</option>
+              <option value="GBP">GBP — £ British Pound</option>
+              <option value="CAD">CAD — $ Canadian Dollar</option>
+              <option value="AUD">AUD — $ Australian Dollar</option>
+            </select>
             <div class="helper-text">These settings are saved on this device.</div>
             <button type="submit" class="btn-primary" style="margin-top:10px;">Save Settings</button>
           </form>

--- a/sidebar.js
+++ b/sidebar.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const settingsModal = document.getElementById('settingsModal');
     const settingsForm = document.getElementById('settingsForm');
     const settingPinSidebar = document.getElementById('settingPinSidebar');
+    const settingCurrency = document.getElementById('settingCurrency');
     const closeButtons = document.querySelectorAll('.modal-close');
     const myGiftsList = document.getElementById('myGiftsList');
     const addGiftForm = document.getElementById('addGiftForm');
@@ -57,6 +58,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Apply saved settings on load
     applyPinnedFromSettings(getSettings());
+    // Ensure default currency is set
+    try {
+        const initSettings = getSettings();
+        if (!initSettings.currency) {
+            initSettings.currency = 'USD';
+            saveSettings(initSettings);
+        }
+    } catch {}
 
     // Sidebar pin toggle
     sidebarPin.addEventListener('click', () => {
@@ -288,6 +297,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (modal === settingsModal) {
             const s = getSettings();
             if (settingPinSidebar) settingPinSidebar.checked = !!s.pinSidebarDefault;
+            if (settingCurrency) settingCurrency.value = s.currency || 'USD';
         }
 
         // Show the modal
@@ -365,6 +375,7 @@ document.addEventListener('DOMContentLoaded', () => {
         e.preventDefault();
         const s = getSettings();
         s.pinSidebarDefault = !!settingPinSidebar?.checked;
+        s.currency = settingCurrency?.value || 'USD';
         saveSettings(s);
         applyPinnedFromSettings(s);
         showToast('Settings saved');


### PR DESCRIPTION
Add a currency selection setting to the sidebar, defaulting to USD.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc916952-003e-404b-97d4-7c630c09f653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc916952-003e-404b-97d4-7c630c09f653">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

