### PR TITLE
Clear preset text in gift list link mode

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -223,9 +223,9 @@
       </div>
       <div id="linkFields" style="display:none;">
         <label for="devLinkUrl">Product link (http/https):</label>
-        <input type="url" id="devLinkUrl" placeholder="https://example.com/product" pattern="https?://.*">
+        <input type="url" id="devLinkUrl" pattern="https?://.*">
         <label for="devLinkCaption" style="margin-top:8px;">Optional caption/title:</label>
-        <input type="text" id="devLinkCaption" placeholder="e.g., LEGO City Fire Truck">
+        <input type="text" id="devLinkCaption">
       </div>
       <button type="submit" class="submit-btn">Add My Gift Ideas</button>
     </form>
@@ -259,9 +259,9 @@
       </div>
       <div id="devKidsLinkFields" class="form-group" style="display:none;">
         <label for="devKidLinkUrl">Product link (http/https):</label>
-        <input type="url" id="devKidLinkUrl" placeholder="https://example.com/product" pattern="https?://.*">
+        <input type="url" id="devKidLinkUrl" pattern="https?://.*">
         <label for="devKidLinkCaption" style="margin-top:8px;">Optional caption/title:</label>
-        <input type="text" id="devKidLinkCaption" placeholder="e.g., LEGO City Fire Truck">
+        <input type="text" id="devKidLinkCaption">
       </div>
 
       <div class="tips-section">


### PR DESCRIPTION
Remove placeholder text from link mode input fields for both gift lists as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-a59d5e43-bbd8-4060-903c-0f6ef4a2856d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a59d5e43-bbd8-4060-903c-0f6ef4a2856d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes placeholder text from the URL and caption fields in link mode for both adult and kids gift forms in Index.html.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1cd554db82dbe0f6c92d25a286753ba114c3fe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->