### PR TITLE
Highlight claimed gifts and fix unclaimed filter

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -442,7 +442,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 const isLocal = String(g.id).startsWith('local-kid-');
                 const isClaimed = !!g.claimed_by;
                 const isMine = isClaimed && me && String(g.claimed_by) === String(me);
-                if (onlyUnclaimed && isClaimed && !isMine && !isLocal) return; // skip
+                // When filtering for only unclaimed, exclude all claimed items (including mine or local)
+                if (onlyUnclaimed && isClaimed) return; // skip any claimed items
                 let itemStateClass = 'gift-unclaimed';
                 if (isClaimed && isMine) itemStateClass = 'gift-claimed-mine';
                 else if (isClaimed) itemStateClass = 'gift-claimed-other';

--- a/style.css
+++ b/style.css
@@ -507,8 +507,17 @@ body {
 
 /* Claim state styling */
 .gift-item.gift-unclaimed { border-color: var(--color-border); }
-.gift-item.gift-claimed-mine { border-color: var(--status-done); box-shadow: 0 0 0 1px var(--status-done) inset; }
-.gift-item.gift-claimed-other { border-color: var(--status-hold); box-shadow: 0 0 0 1px var(--status-hold) inset; opacity: 0.92; }
+/* Highlight entire card when claimed */
+.gift-item.gift-claimed-mine {
+  border-color: var(--status-done);
+  box-shadow: 0 0 0 1px var(--status-done) inset;
+  background: rgba(16,185,129,0.10); /* green tint */
+}
+.gift-item.gift-claimed-other {
+  border-color: var(--status-hold);
+  box-shadow: 0 0 0 1px var(--status-hold) inset;
+  background: rgba(217,119,6,0.12); /* amber tint */
+}
 
 .claimer-badge {
   background: rgba(12,90,58,0.12);


### PR DESCRIPTION
Add full-card highlighting for claimed gift items and fix the "Show only unclaimed" filter to correctly hide all claimed items.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd57b59-40c7-498f-ac15-df3479ef10d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6dd57b59-40c7-498f-ac15-df3479ef10d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

