### PR TITLE
Investigate and fix gift unclaiming bug

### DIFF
--- a/sidebar.js
+++ b/sidebar.js
@@ -551,8 +551,16 @@ document.addEventListener('DOMContentLoaded', () => {
                           .from('kid_gifts')
                           .update({ claimed_by: null, claimed_at: null })
                           .eq('id', idAttr)
+                          .eq('claimed_by', me)
                           .select('id');
-                        if (error) throw error;
+                        if (error) {
+                            const msg = String(error?.message || '').toLowerCase();
+                            if (error.code === '42501' || msg.includes('row-level security') || msg.includes('permission')) {
+                                showToast('Cannot unclaim (not yours)', 'error');
+                                return false;
+                            }
+                            throw error;
+                        }
                         if (!data || data.length === 0) { showToast('Cannot unclaim (not yours)', 'error'); return false; }
                         showToast('Unclaimed');
                         return true;


### PR DESCRIPTION
Add ownership check and specific error handling to the unclaim gift mutation to prevent unauthorized unclaims and provide clearer user feedback.

Previously, the unclaim mutation relied solely on Row-Level Security (RLS) for ownership enforcement. This could result in generic "Failed to unclaim" errors or silent failures when a user attempted to unclaim a gift not claimed by them. This change explicitly checks `claimed_by` in the update query and provides a user-friendly "Cannot unclaim (not yours)" message for permission denials, improving user experience and system robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee284cd7-4325-4b5e-a046-ec87ce9f87ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee284cd7-4325-4b5e-a046-ec87ce9f87ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

